### PR TITLE
Added HTML encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"html"
 	"log"
 	"os"
 	"strings"
@@ -37,7 +38,20 @@ func ParsePageData(path string) PageData {
 	if err != nil {
 		log.Fatalf("Failed parsing %s: %v", path, err)
 	}
-	return pageData
+	return encodePageData(pageData)
+}
+
+func encodePageData(data PageData) PageData {
+	data.Title = html.EscapeString(data.Title)
+	data.Description = html.EscapeString(data.Description)
+	for i := 0; i < len(data.Sections); i++ {
+		data.Sections[i].Title = html.EscapeString((data.Sections[i].Title))
+		for j := 0; j < len(data.Sections[i].Items); j++ {
+			data.Sections[i].Items[j].Term = html.EscapeString(data.Sections[i].Items[j].Term)
+			data.Sections[i].Items[j].Description = html.EscapeString(data.Sections[i].Items[j].Description)
+		}
+	}
+	return data
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"html"
 	"log"
 	"os"
 	"strings"
@@ -38,20 +37,7 @@ func ParsePageData(path string) PageData {
 	if err != nil {
 		log.Fatalf("Failed parsing %s: %v", path, err)
 	}
-	return encodePageData(pageData)
-}
-
-func encodePageData(data PageData) PageData {
-	data.Title = html.EscapeString(data.Title)
-	data.Description = html.EscapeString(data.Description)
-	for i := 0; i < len(data.Sections); i++ {
-		data.Sections[i].Title = html.EscapeString((data.Sections[i].Title))
-		for j := 0; j < len(data.Sections[i].Items); j++ {
-			data.Sections[i].Items[j].Term = html.EscapeString(data.Sections[i].Items[j].Term)
-			data.Sections[i].Items[j].Description = html.EscapeString(data.Sections[i].Items[j].Description)
-		}
-	}
-	return data
+	return pageData
 }
 
 func main() {

--- a/templates/printable.html
+++ b/templates/printable.html
@@ -90,19 +90,19 @@
 
   <body>
     <div id="preamble">
-      <h1 class="title">{{ .Title }}</h1>
-      <p class="description">{{ .Description }}</p>
+      <h1 class="title">{{ .Title | html }}</h1>
+      <p class="description">{{ .Description | html }}</p>
     </div>
 
     <div class="container">
       <div id="column-1" class="column">
         {{ range $section := .Sections }}
         <div class="section">
-          <h2 class="section-title">{{ $section.Title }}</h2>
+          <h2 class="section-title">{{ $section.Title | html }}</h2>
           {{ range $item := $section.Items }}
           <p class="line-item">
-            <span class="line-term">{{ $item.Term }}</span>
-            <span class="line-desc">{{ $item.Description}}</span>
+            <span class="line-term">{{ $item.Term | html }}</span>
+            <span class="line-desc">{{ $item.Description | html }}</span>
           </p>
           {{ end }}
         </div>


### PR DESCRIPTION
Hi! Thanks for making the tool! I wanted to use it to get a custom neovim cheat sheet printed out. As I was preparing my template I realized the strings are not encoded for HTML (I couldn't figure out why my keybinds where missing and then realized things like e.x. `<C-w>` were being treated as HTML), so I added a part encoding every string that's going into the HTML. I'm very new to Go so do let me know if this could be handled better in the language!